### PR TITLE
185 quick install

### DIFF
--- a/bootstrap.Dockerfile
+++ b/bootstrap.Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+WORKDIR /root
+
+RUN apk update && \
+    apk add bash curl docker-cli docker-cli-compose git jq make openssl zip unzip
+
+COPY ./scripts/ /usr/local/bin

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env sh
+
+print_help() {
+  cat >&2 <<EOF
+USAGE: $0 [OPTIONS…] [configuration]
+
+OPTIONS:
+  -d|--dry-run        Don't do anything, instead print what would be done
+  -h|--help           Display this help
+  -i|--install-docker Install docker if missing without prompting
+  -u|--username       Admin username
+  -p|--password       Admin password
+  --no-open           Don't open the browser
+
+ARGUMENTS:
+  configuration       Installation configuration (one of empty, pms-core, pms-core-demo-data)
+EOF
+}
+
+# Flags definitions
+open_browser=true
+install_docker=false
+dry_run=false
+bootstrap_image=
+admin_username=
+admin_password=
+
+# Flags parsing
+while :; do
+  case "$1" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    -i|--install-docker)
+      install_docker=true
+      ;;
+    -d|--dry-run)
+      dry_run=true
+      ;;
+    --no-open)
+      open_browser=false
+      ;;
+    -u|--username)
+      if [ -n "$2" ]; then
+        admin_username="$2"
+        shift
+      else
+        echo "--username requires an argument"
+      fi
+      ;;
+    -p|--password)
+      if [ -n "$2" ]; then
+        admin_password="$2"
+        shift
+      else
+        echo "--password requires an argument"
+      fi
+      ;;
+    # Undocumented flag for development where the bootstrap image is not on Docker hub
+    --bootstrap-image)
+      if [ -n "$2" ]; then
+        bootstrap_image="$2"
+        shift
+      else
+        echo "--bootstrap-image requires an argument"
+      fi
+      ;;
+    -*)
+      echo "Invalid flag: $1"
+      print_help
+      exit 255
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+
+# Arguments
+database="$1"
+
+################################################################################
+# COMMON FUNCTIONS (copied from scripts/common_functions.sh                    #
+################################################################################
+
+# Printing helpers
+csi_reset="\033[0m"
+csi_bold="\033[1m"
+csi_fg_default="\033[39m"
+csi_fg_red="\033[91m"
+csi_fg_green="\033[92m"
+csi_fg_blue="\033[94m"
+
+
+# cmd_open=$(command -v xdg-open || command -v open || 'cmd_open_fallback')
+cmd_open='cmd_open_fallback'
+
+print_newline() {
+  echo >&2
+}
+
+print_step() {
+ echo "$csi_bold$csi_fg_blue :: $csi_fg_default$1$csi_reset" >&2
+}
+
+print_step_info() {
+  echo "    $1" >&2
+}
+
+print_step_warning() {
+  echo " ⚠  $1" >&2
+}
+
+fatal_step_error() {
+  echo " 🛑 $1" >&2
+  exit 255
+}
+
+print_prerequisite_status() (
+  name=$1
+  found=$2
+  status=$([ "$found" -eq 0 ] && echo "$csi_fg_green found" || echo "$csi_fg_red missing")
+  printf "    - %-20s %s $csi_fg_default\n" "$name" "$status" >&2
+)
+
+print_option() (
+  name=$1
+  description=$2
+  printf "    - ${csi_bold}%-20s${csi_reset} %s\n" "$name" "$description"
+)
+
+print_prompt() {
+  printf "    %s " "$1" >&2
+  read -r "$2"
+}
+
+cmd_open_fallback() {
+  print_step_info "Click to open $1"
+}
+
+################################################################################
+# END OF COMMON FUNCTIONS                                                      #
+################################################################################
+
+# Utility functions
+
+install_docker() {
+  print_step "Install Docker"
+
+  print_step_info "Downloading install script"
+  curl -fsSL https://get.docker.com -o install-docker.sh
+
+  print_step_info "Simulating install script"
+  sh install-docker.sh --dry-run
+
+  confirm=
+  if [ "$install_docker" = "true" ]; then
+    confirm=Y
+  fi
+
+  until [ -n "$confirm" ]; do
+    print_prompt "Install? (yN)" confirm
+    case "$confirm" in
+      [Nn])
+        fatal_step_error "Docker not installed. Exiting"
+        ;;
+      "")
+        fatal_step_error "Docker not installed. Exiting"
+        ;;
+      [Yy])
+        print_step_info "Installing docker"
+        ;;
+      *)
+        confirm=
+        ;;
+    esac
+  done
+  sh install-docker.sh
+
+}
+
+check_prerequisites() {
+  print_step "Prerequisites check"
+
+  command -v docker > /dev/null 2>&1
+  has_docker=$?
+  print_prerequisite_status docker "$has_docker"
+
+  if [ "$has_docker" -ne 0 ]; then
+    command -v curl > /dev/null 2>&1
+    has_curl=$?
+    print_prerequisite_status curl "$has_curl"
+  fi
+}
+
+create_bootstrap_image() {
+  print_step "Get bootstrap container"
+  if [ -f "bootstrap.Dockerfile" ]; then
+    print_step_info "Building local boostrap container"
+    docker build --tag "finmars/bootstrap:latest" --quiet -f bootstrap.Dockerfile .
+  elif [ -n "$bootstrap_image" ]; then
+    print_step_info "Loading bootstrap container file"
+    docker image load -q >&2 < "$bootstrap_image"
+    echo "finmars/bootstrap:latest"
+  else
+    print_step_info "Pulling boostrap image"
+    docker pull --progress quiet "docker.io/finmars/bootstrap:latest"
+  fi
+}
+
+run_bootstrap_container() {
+  print_step "Run bootstrap container"
+  host_dir="$PWD/finmars-community-edition"
+  mkdir -p "$host_dir"
+  docker run --rm --interactive --use-api-socket --volume "$host_dir:$host_dir" --workdir "$host_dir" --env "ADMIN_USERNAME=$admin_username" --env "ADMIN_PASSWORD=$admin_password" "$1" sh <<EOF
+   #!/usr/bin/env sh
+   set -eux
+   export COMPOSE_PROGRESS=quiet
+   if [ ! -d ".git" ]; then
+     git clone --depth 1 https://github.com/finmars-platform/finmars-community-edition.git .
+   fi
+   install-demo.sh $2
+   make up
+EOF
+}
+
+choose_credentials() {
+  print_step "Admin credentials"
+
+  until [ -n "$admin_username" ]; do
+    print_prompt "Enter admin username:" admin_username
+  done
+
+  until [ -n "$admin_password" ]; do
+    print_prompt "Enter admin password:" admin_password
+  done
+}
+
+choose_demo_db() {
+  print_step "Select demo setup"
+
+  if [ -n "$database" ] && [ ! "$database" = "empty" ] && [ ! "$database" = "pms-core" ] && [ ! "$database" = "pms-core-demo-data" ]; then
+    print_step_warning "'$database' is not a valid configuration"
+    database=
+  fi
+
+  until [ -n "$database" ]; do
+    print_step_info "Choose one of the following demo setups:"
+    print_option "empty"              "Minimal setup without configurations or demo data (e)"
+    print_option "pms-core"           "PMS-core preconfigured, without demo data (p)"
+    print_option "pms-core-demo-data" "PMS-core preconfigured, with demo data (default)"
+    print_newline
+    print_prompt "    Which demo database to use? (epD): " db
+    case "$db" in
+      e|E|empty)
+        database="empty"
+        ;;
+      p|P|pms|PMS|pms-core|PMS-CORE)
+        database="pms-core"
+        ;;
+      d|D|demo|DEMO|demo-data|DEMO-DATA|"")
+        database="pms-core-demo-data"
+        ;;
+      *)
+        echo "Invalid choice"
+        ;;
+    esac
+  done
+  print_step_info "Using '$database'"
+}
+
+check_prerequisites
+
+if [ "$has_docker" -ne 0 ]; then
+  install_docker
+fi
+
+choose_credentials
+choose_demo_db
+bootstrap_container=$(create_bootstrap_image)
+echo "Bootstrap container: '$bootstrap_container'"
+
+run_bootstrap_container "$bootstrap_container" "$database"
+
+print_step "Opening Finmars"
+$cmd_open https://127.0.0.1/

--- a/scripts/common_functions.sh
+++ b/scripts/common_functions.sh
@@ -19,11 +19,17 @@ print_newline() {
 }
 
 print_step() {
- echo "$csi_bold$csi_fg_blue :: $csi_fg_default$1$csi_reset" >&2
+  echo "$csi_bold$csi_fg_blue :: $csi_fg_default$1$csi_reset" >&2
+  if [ -n "$installer_mode" ]; then
+    echo "INSTALLER:CURSTEP:$1"
+  fi
 }
 
 print_step_info() {
   echo "    $1" >&2
+  if [ -n "$installer_mode" ]; then
+    echo "INSTALLER:STEPINF:$1"
+  fi
 }
 
 print_step_warning() {

--- a/scripts/common_functions.sh
+++ b/scripts/common_functions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+# Printing helpers
+csi_reset="\033[0m"
+csi_bold="\033[1m"
+csi_fg_default="\033[39m"
+csi_fg_red="\033[91m"
+csi_fg_green="\033[92m"
+csi_fg_blue="\033[94m"
+
+print_newline() {
+  echo >&2
+}
+
+print_step() {
+ echo "$csi_bold$csi_fg_blue :: $csi_fg_default$1$csi_reset" >&2
+}
+
+print_step_info() {
+  echo "    $1" >&2
+}
+
+print_step_warning() {
+  echo " ⚠  $1" >&2
+}
+
+fatal_step_error() {
+  echo " 🛑 $1" >&2
+  exit 255
+}
+
+print_prerequisite_status() (
+  name=$1
+  found=$2
+  status=$([ "$found" -eq 0 ] && echo "$csi_fg_green found" || echo "$csi_fg_red missing")
+  printf "    - %-20s %s $csi_fg_default\n" "$name" "$status" >&2
+)
+
+print_option() (
+  name=$1
+  description=$2
+  printf "    - ${csi_bold}%-20s${csi_reset} %s\n" "$name" "$description"
+)
+
+print_prompt() {
+  printf "    %s " "$1" >&2
+  read -r "$2"
+}
+
+cmd_open_fallback() {
+  print_step_info "Click to open $1"
+}
+
+cmd_open=$(command -v xdg-open || command -v open || 'cmd_open_fallback')

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -26,7 +26,7 @@ docker compose up -d db
 sleep 5
 
 echo "⏳ Waiting for PostgreSQL to be ready..."
-until docker exec $(docker compose ps -q db) pg_isready -U ${DB_USER} > /dev/null 2>&1; do
+until docker compose exec db pg_isready -U ${DB_USER} > /dev/null 2>&1; do
   sleep 1
 done
 
@@ -38,14 +38,21 @@ echo "📤 Exporting SQL databases..."
 # Export backend database
 backend_dump_filepath="${DUMP_DIR}/backend.sql"
 echo "📤 Exporting database 'backend_realm00000' to 'backend.sql'..."
-docker exec $(docker compose ps -q db) pg_dump -U ${DB_USER} -d backend_realm00000 > "$backend_dump_filepath"
+docker compose exec db pg_dump -U ${DB_USER} -d backend_realm00000 > "$backend_dump_filepath"
 echo "✅ Exported 'backend_realm00000' to 'backend.sql'."
 
 # Export workflow database
 workflow_dump_filepath="${DUMP_DIR}/workflow.sql"
 echo "📤 Exporting database 'workflow_realm00000' to 'workflow.sql'..."
-docker exec $(docker compose ps -q db) pg_dump -U ${DB_USER} -d workflow_realm00000 > "$workflow_dump_filepath"
+docker compose exec db pg_dump -U ${DB_USER} -d workflow_realm00000 > "$workflow_dump_filepath"
 echo "✅ Exported 'workflow_realm00000' to 'workflow.sql'."
+
+# Export storage
+storage_dump_filepath="${DUMP_DIR}/storage.tar.gz"
+echo "📤 Exporting file storage to 'storage.tar.gz'..."
+docker compose exec core tar -C /var/app/finmars_data -cz /var/app/finmars_data > "$storage_dump_filepath"
+echo "✅ Exported file storage to 'storage.tar.gz'."
+
 
 # Function to get current version for an app
 get_current_version() {
@@ -104,7 +111,7 @@ cat > "$manifest_filepath" << EOF
     "versions": ${versions_json},
     "date": "${backup_date}",
     "owner": {
-        "username": "community_edition"
+        "username": "${ADMIN_USERNAME}"
     }
 }
 EOF

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -1,8 +1,72 @@
 #!/bin/bash
 
+show_help() {
+  cat - <<EOF
+$0 [OPTIONS…] [ENVIRONMENT_TYPE]
+
+OPTIONS:
+  -k|--keep-env  Never overwrite the .env file
+  -u|--username  The admin username
+  -p|--password  The admin password
+  -h|--help      Show this help
+
+ARGUMENTS:
+  ENVIRONMENT_TYPE=l|h  The environment type to setup, (l)ocal or (p)roduction
+
+EOF
+}
+
+overwrite_env=
+ADMIN_USERNAME=
+ADMIN_PASSWORD=
+
+# Handle CLI options
+while :; do
+  case "$1" in
+    -h|--help)
+      show_help
+      exit
+      ;;
+    -k|--keep-env)
+      overwrite_env=n
+      ;;
+    -u|--username)
+      if [ -n "$2" ]; then
+        ADMIN_USERNAME="$2"
+        shift
+      else
+        echo "Error: must specify username after --username" >&2
+        exit 255
+      fi
+      ;;
+    -p|--password)
+      if [ -n "$2" ]; then
+        ADMIN_PASSWORD="$2"
+        shift
+      else
+        echo "Error: must specify password after --password" >&2
+        exit 255
+      fi
+      ;;
+    --)
+      break
+      ;;
+    *)
+      break
+      ;;
+    esac
+    shift
+done
+
+# Handle arguments
+environment_type="$1"
+shift
+
 if [ -f .env ]; then
-  read -p ".env already exists. Overwrite? (y/N): " confirm
-  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  if [ -z "$overwrite_env" ]; then
+    read -p ".env already exists. Overwrite? (y/N): " overwrite_env
+  fi
+  if [[ ! "$overwrite_env" =~ ^[Yy]$ ]]; then
     echo "Aborted. Keeping existing .env file."
     if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
       return 0
@@ -15,8 +79,11 @@ fi
 PROTO="https"
 COMPOSE_FILE="docker-compose.yml"
 
-read -p "Which version will you use? Local or production (l/P): " confirm
-if [[ ! "$confirm" =~ ^[Ll]$ ]]; then
+if [ -z "$environment_type" ]; then
+  read -p "Which version will you use? Local or production (l/P): " environment_type
+fi
+
+if [[ ! "$environment_type" =~ ^[Ll]$ ]]; then
   ENVIRONMENT_TYPE=production
   AUTH_DOMAIN_PORT=443
 
@@ -37,9 +104,12 @@ else
   VERIFY_SSL=False
 fi
 
-
-read -p "Enter ADMIN_USERNAME: " ADMIN_USERNAME
-read -sp "Enter ADMIN_PASSWORD: " ADMIN_PASSWORD
+if [ -z "$ADMIN_USERNAME" ]; then
+  read -p "Enter ADMIN_USERNAME: " ADMIN_USERNAME
+fi
+if [ -z "$ADMIN_PASSWORD" ]; then
+  read -sp "Enter ADMIN_PASSWORD: " ADMIN_PASSWORD
+fi
 echo
 
 ESCAPED_ADMIN_USERNAME=$(printf '%s\n' "$ADMIN_USERNAME" | sed -e 's/[\/&]/\\&/g')

--- a/scripts/install-demo.sh
+++ b/scripts/install-demo.sh
@@ -1,17 +1,40 @@
 #!/usr/bin/env sh
 # Usage: install-demo.sh <database-dump>
 
+# Note: will not work when sourced from a different directory
+script_dir=$(dirname "$0")
+. "$script_dir/common_functions.sh"
+
+
 dump_name="$1"
 dump_file="db-dump-$dump_name"
 
+print_step "Downloading database configuration"
 s3_url="https://finmars-public.s3.eu-central-1.amazonaws.com"
 curl -o "$dump_file.zip" "$s3_url/$dump_file.zip"
 
+print_step "Setting up environment"
 generate-env.sh -k -u "$ADMIN_USERNAME" -p "$ADMIN_PASSWORD" l
+
+print_step "Downloading Finmars"
+if [ -n "$installer_mode" ]; then
+    export COMPOSE_PROGRESS=json
+fi
+docker compose pull
+
 if [ ! -d "nginx/ssl/live" ]; then
+  #print_step "Setting up certificates"
   init-cert.sh
 fi
+
+print_step "Adding users"
 init-keycloak.sh
+
+print_step "Checking for updates"
 update-versions.sh
+
+print_step "Importing configuration"
 restore-backup.sh "$dump_file.zip"
+
+print_step "Adjusting database configuration"
 patch-demo-database.sh

--- a/scripts/install-demo.sh
+++ b/scripts/install-demo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Usage: install-demo.sh <database-dump>
+
+dump_name="$1"
+dump_file="db-dump-$dump_name"
+
+s3_url="https://finmars-public.s3.eu-central-1.amazonaws.com"
+curl -o "$dump_file.zip" "$s3_url/$dump_file.zip"
+
+generate-env.sh -k -u "$ADMIN_USERNAME" -p "$ADMIN_PASSWORD" l
+if [ ! -d "nginx/ssl/live" ]; then
+  init-cert.sh
+fi
+init-keycloak.sh
+update-versions.sh
+restore-backup.sh "$dump_file.zip"
+patch-demo-database.sh

--- a/scripts/patch-demo-database.sh
+++ b/scripts/patch-demo-database.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+
+# Note: will not work when sourced from a different directory
+script_dir=$(dirname "$0")
+. "$script_dir/common_functions.sh"
+
+run_sql()
+{
+  docker compose exec db psql --username "${DB_USER}" --dbname "$1" --command "$2"
+}
+
+# SQL SCRIPTS
+sql_change_listview_dates="
+-- Update date keys if they are present, ignore date keys which aren't
+UPDATE space00000.ui_listlayout AS ull
+SET json_data = updated.json_data
+FROM (SELECT id,
+             jsonb_set(
+             jsonb_set(
+             jsonb_set(
+                 CASE
+                     WHEN json_data::jsonb #>> '{reportLayoutOptions,datepickerOptions,reportFirstDatepicker,date}' = '0001-01-01'
+                     THEN json_data::jsonb
+                     ELSE jsonb_set(json_data::jsonb,
+                                    '{reportLayoutOptions,datepickerOptions,reportFirstDatepicker,date}', '\"2022-12-01\"', false)
+                 END,
+                 '{reportLayoutOptions,datepickerOptions,reportLastDatepicker,date}', '\"2025-03-31\"', false),
+                 '{reportOptions,begin_date}', '\"2022-12-01\"', false),
+                 '{reportOptions,end_date}', '\"2025-03-31\"', false)
+              as json_data
+      FROM space00000.ui_listlayout) AS updated
+WHERE ull.id = updated.id;
+"
+
+print_step "Updating demo database"
+
+print_step_info "Setting report date picker to demo data range"
+print_step_info "$(run_sql "backend_realm00000" "$sql_change_listview_dates")"

--- a/scripts/patch-demo-database.sh
+++ b/scripts/patch-demo-database.sh
@@ -32,7 +32,6 @@ FROM (SELECT id,
 WHERE ull.id = updated.id;
 "
 
-print_step "Updating demo database"
 
 print_step_info "Setting report date picker to demo data range"
-print_step_info "$(run_sql "backend_realm00000" "$sql_change_listview_dates")"
+run_sql "backend_realm00000" "$sql_change_listview_dates"

--- a/scripts/restore-backup.sh
+++ b/scripts/restore-backup.sh
@@ -9,6 +9,7 @@ set -e
 BACKUP_FILE="${1:-tmp/backup.zip}"
 EXTRACT_DIR="tmp/backup_extracted"
 MANIFEST_FILE="${EXTRACT_DIR}/manifest.json"
+STORAGE_FILE='storage.tar.gz'
 
 # Function to find the latest backup directory
 find_latest_backup() {
@@ -126,6 +127,7 @@ echo "🔍 Checking version compatibility..."
 
 # Extract versions from manifest
 backup_versions=$(jq -r '.versions[] | "\(.app)=\(.version)"' "$MANIFEST_FILE")
+owner_username=$(jq -r '.owner.username' "$MANIFEST_FILE")
 
 version_mismatch=false
 
@@ -198,7 +200,7 @@ docker compose up -d db
 sleep 5
 
 echo "⏳ Waiting for PostgreSQL to be ready..."
-until docker exec $(docker compose ps -q db) pg_isready -U ${DB_USER} > /dev/null 2>&1; do
+until docker compose exec db pg_isready -U ${DB_USER} > /dev/null 2>&1; do
   sleep 1
 done
 
@@ -212,7 +214,7 @@ drop_existing_databases() {
         DB_NAME="${SERVICE_NAME}_realm00000"
         
         echo "🗑️ Dropping database '$DB_NAME'..."
-        if docker exec $(docker compose ps -q db) psql -U ${DB_USER} -c "DROP DATABASE IF EXISTS ${DB_NAME};" > /dev/null 2>&1; then
+        if docker compose exec db psql -U ${DB_USER} -c "DROP DATABASE IF EXISTS ${DB_NAME};" > /dev/null 2>&1; then
             echo "✅ Dropped database '$DB_NAME'"
         else
             echo "⚠️ Database '$DB_NAME' may not have existed or couldn't be dropped"
@@ -238,14 +240,14 @@ for SERVICE_NAME in backend workflow; do
   
   # Create database before importing
   echo "📦 Creating database '$DB_NAME'..."
-  if ! docker exec $(docker compose ps -q db) psql -U ${DB_USER} -c "CREATE DATABASE ${DB_NAME};" > /dev/null 2>&1; then
+  if ! docker compose exec db psql -U ${DB_USER} -c "CREATE DATABASE ${DB_NAME};" > /dev/null 2>&1; then
     echo "⚠️ Database '$DB_NAME' may already exist or creation failed"
   else
     echo "✅ Created database '$DB_NAME'"
   fi
   
   echo "📥 Importing database '$DB_NAME' from '$SQL_FILE'..."
-  if ! docker exec -i $(docker compose ps -q db) psql -U ${DB_USER} -d ${DB_NAME} < "${EXTRACT_DIR}/${SQL_FILE}"; then
+  if ! docker compose exec -i db psql -U ${DB_USER} -d ${DB_NAME} < "${EXTRACT_DIR}/${SQL_FILE}"; then
     echo "✗ Failed to import ${SERVICE_NAME} database!"
     exit 1
   fi
@@ -253,6 +255,27 @@ for SERVICE_NAME in backend workflow; do
 done
 
 echo "✅ SQL import completed successfully!"
+
+new_username=$ADMIN_USERNAME
+echo "🫅 Updating owner from '$owner_username' to '$new_username'"
+if ! echo "UPDATE space00000.users_member SET username = :'new_username' WHERE username = :'old_username';" \
+  | docker compose exec -i db psql -U "${DB_USER}" -d "backend_realm00000" \
+    -v "old_username=$owner_username" -v "new_username=$new_username"; then
+    echo "✗ Failed to update owner!"
+    exit 1
+fi
+echo "🫅 Updated owner"
+
+echo "🚀 Starting core container..."
+docker compose up core -d
+echo "✅ Core container is ready"
+
+echo "💾 Importing storage from $STORAGE_FILE"
+if ! cat "$EXTRACT_DIR/$STORAGE_FILE" | docker compose exec -i core tar -C /var/app/finmars_data -xzf -; then
+  echo "Failed to import storage"
+  exit 1
+fi
+echo "✅ Storage import done"
 
 echo "🗑️ Cleaning up temporary files..."
 rm -rf "$EXTRACT_DIR"


### PR DESCRIPTION
- common_functions.sh contains some shared utilities
- create-dumps.sh creates a tarball of the storage into the backup and saves the username.
- generate-env.sh accepts command line arguments to skip prompts. This is not used right now, but will be used by the GUI wrapper of this script.
- patch-demo-database.sh updates the views so the date range for reports are set to the range of the demo data
- restore-backup.sh restores the tarball of the storage and updates the member name if the user specified a different one than in the backup.

Contributes to #185

Since the bootstrap container is not yet published to the DockerHub, to test it, you'll have to run either:

* run `quick-install.sh` in this directory
* build it "docker build -f bootstrap.Dockerfile -t "finmars/bootstrap:latest"; docker save "finmars/bootstrap:latest" > bootstrap.tar` .` and run `quick-install.sh --bootstrap-image <path-to-bootstrap.tar>`

I tested it in a fresh install of Debian Linux with only the bootstrap.tar and the quick-install.sh present and it works for me. It usually takes about 4 minutes to run.