### PR TITLE
SSL config updates

### DIFF
--- a/openssl.conf
+++ b/openssl.conf
@@ -6,11 +6,10 @@ distinguished_name      = dn
 x509_extensions         = x509_ext
 
 [ dn ]
-C  = US
-ST = California
-L  = San Francisco
-O  = My Organization
-OU = My Organizational Unit
+C  = LU
+ST = Luxembourg
+L  = Luxembourg
+O  = Finmars SCSA
 CN = localhost
 
 [ x509_ext ]

--- a/openssl.conf
+++ b/openssl.conf
@@ -1,9 +1,9 @@
 [ req ]
-default_bits        = 2048
-prompt              = no
-default_md          = sha256
-distinguished_name  = dn
-req_extensions      = req_ext
+default_bits            = 2048
+prompt                  = no
+default_md              = sha256
+distinguished_name      = dn
+x509_extensions         = x509_ext
 
 [ dn ]
 C  = US
@@ -13,11 +13,14 @@ O  = My Organization
 OU = My Organizational Unit
 CN = localhost
 
-[ req_ext ]
-subjectAltName = @alt_names
+[ x509_ext ]
+subjectAltName          = @alt_names
+subjectKeyIdentifier    = hash
+basicConstraints        = critical, CA:false
+keyUsage                = critical, digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage        = serverAuth
 
 [ alt_names ]
 DNS.1 = localhost
 IP.1 = 127.0.0.1
-DNS.2 = localhost
-IP.2 = 127.0.0.1
+IP.2 = ::1


### PR DESCRIPTION
In the context of self-signed certificate for the local installer:

1. Actually set the alt names. The _req_ext_ configuration section was not used by `scripts/init-cert.sh`, because it passes the `-x509` option. This enforces that the certificate is only used for serving from localhost.
2. While we're at it, properly set the _basicConstrains_, _keyUsage_ and _extendedKeyUsage_ so that this certificate won't be used besides what it was generated for: an HTTPS server. This prevents it from being used to sign code, sign any other certificates and all kinds of other funky business
3. Set the distinguished name to something sensible, so that users recognise that this certificate originates from Finmars and not some nonsensical "My Organisation"

Properly setting up the SSL certificate is needed, so that the embedded browser in the local installer can trust this certificate and doesn't need to blindly accept all certificates.