### PR TITLE
CI: run linters on all branches and on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,8 @@ name: CI Linters
 on:
   push:
     branches:
-      - '*'
+      - '**'
+  pull_request:
 
 permissions:
   contents: write 


### PR DESCRIPTION
## Problem

The `CI Linters` workflow only triggers on `push` with `branches: ['*']`. In GitHub Actions globs the `*` wildcard **does not match `/`**, so branch names containing a slash (e.g. `fix/...`, `ci/...`) never trigger CI — the workflow silently doesn't run for them. There is also no `pull_request` trigger, so PRs get no checks of their own.

## Fix

- `branches: ['**']` — `**` matches across `/`, so nested branch names are covered.
- Add a `pull_request` trigger so every PR is linted/tested regardless of its branch name.

No job logic changes.