### PR TITLE
CI: drop duplicate pull_request trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
 
 permissions:
   contents: write 


### PR DESCRIPTION
Follow-up to #57. With both `push: ['**']` and `pull_request`, each PR-branch push triggered two identical runs (push + pull_request), so every PR showed duplicated Lint/Test checks.

Keep only `push: ['**']` — it already runs on every branch (including slashed names like `fix/...`) and those runs are surfaced on the PR, so one set of checks is enough. No job logic changes.